### PR TITLE
Create about page with component licenses

### DIFF
--- a/colvert/ui/routes/__init__.py
+++ b/colvert/ui/routes/__init__.py
@@ -2,5 +2,6 @@ from .completion import routes as completion
 from .docs import routes as docs
 from .index import routes as index
 from .results import routes as results
+from .about import routes as about
 
-routes = [*index, *results, *completion, *docs]
+routes = [*index, *results, *completion, *docs, *about]

--- a/colvert/ui/routes/about.py
+++ b/colvert/ui/routes/about.py
@@ -1,0 +1,9 @@
+from aiohttp import web
+import aiohttp_jinja2
+
+routes = web.RouteTableDef()
+
+@routes.get('/about')
+@aiohttp_jinja2.template('about.html.j2')
+async def about(request):
+    return {}

--- a/colvert/ui/templates/about.html.j2
+++ b/colvert/ui/templates/about.html.j2
@@ -1,0 +1,24 @@
+{% extends "layout.html.j2" %}
+
+{% block head %}
+<link rel="stylesheet" href="/static/style.css">
+{% endblock %}
+
+{% block body %}
+<div class="container mt-5">
+    <h1>About Colvert</h1>
+    <p>Colvert is a web frontend for DuckDB designed for data analysis and visualization.</p>
+    <h2>Components and Licenses</h2>
+    <ul>
+        <li>HTMX - License: MIT</li>
+        <li>Tabler - License: MIT</li>
+        <li>Python - License: PSF</li>
+        <li>DuckDB - License: MIT</li>
+        <li>AioHTTP - License: Apache 2.0</li>
+        <li>Bootstrap - License: MIT</li>
+        <li>Monaco Editor - License: MIT</li>
+    </ul>
+    <h2>Author</h2>
+    <p>Colvert was created by Julien Duponchelle. You can find more about the project on <a href="https://github.com/julien-duponchelle/colvert">GitHub</a>.</p>
+</div>
+{% endblock %}

--- a/colvert/ui/templates/about.html.j2
+++ b/colvert/ui/templates/about.html.j2
@@ -1,22 +1,24 @@
 {% extends "layout.html.j2" %}
 
-{% block head %}
-<link rel="stylesheet" href="/static/style.css">
-{% endblock %}
+{% block container %}container{% endblock %}
+
+{% block title %}About Colvert{% endblock %}
 
 {% block body %}
-<div class="container mt-5">
+<div class="container">
     <h1>About Colvert</h1>
     <p>Colvert is a web frontend for DuckDB designed for data analysis and visualization.</p>
+    <h2>License</h2>
+    <p>Colvert is licensed under the Apache 2.0 License.</p>
     <h2>Components and Licenses</h2>
     <ul>
-        <li>HTMX - License: MIT</li>
-        <li>Tabler - License: MIT</li>
         <li>Python - License: PSF</li>
+        <li>HTMX - License: Zero-Clause BSD</li>
         <li>DuckDB - License: MIT</li>
         <li>AioHTTP - License: Apache 2.0</li>
-        <li>Bootstrap - License: MIT</li>
         <li>Monaco Editor - License: MIT</li>
+        <li>Tabler - License: MIT</li>
+        <li>Bootstrap - License: MIT</li>
     </ul>
     <h2>Author</h2>
     <p>Colvert was created by Julien Duponchelle. You can find more about the project on <a href="https://github.com/julien-duponchelle/colvert">GitHub</a>.</p>

--- a/colvert/ui/templates/layout.html.j2
+++ b/colvert/ui/templates/layout.html.j2
@@ -27,6 +27,9 @@
         <li class="nav-item">
           <a class="nav-link" href="/tables">Tables</a>
         </li>
+        <li class="nav-item">
+          <a class="nav-link" href="/about">About</a>
+        </li>
       </ul>
     </nav>
   </header>


### PR DESCRIPTION
Related to #8

Adds a new About page to the Colvert project, detailing the components used and their licenses, as well as information about the project's author.

- **Template Creation**: Adds `about.html.j2` in `colvert/ui/templates`, extending the base layout and including sections for Colvert description, components and their licenses, and author information.
- **Route Handling**: Modifies `colvert/ui/routes/__init__.py` to import and include the new about route. Adds `about.py` in `colvert/ui/routes` to define the route handler for the About page, using `aiohttp_jinja2.template` decorator for rendering.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/julien-duponchelle/colvert/issues/8?shareId=8ae88e73-4f9a-457d-986e-772aab12e0e5).