### PR TITLE
Fix invalid image links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ It's a web frontend running on top of DuckDB. It's support SQL queries and visua
 
 It's support loading data from CSV, Parquet, and JSON files.
 
-![Table screenshot](docs/charts/table/table.png)
-![Pie chart screenshot](docs/charts/pie/pie.png)
+![Table screenshot](colvert/docs/charts/table/table.png)
+![Pie chart screenshot](colvert/docs/charts/pie/pie.png)
 
 ## Installation
 


### PR DESCRIPTION
Related to #15

Corrects the image links in the `README.md` file to ensure they point to the valid paths within the repository.

- Updates the link for the table screenshot to point to `colvert/docs/charts/table/table.png`.
- Updates the link for the pie chart screenshot to point to `colvert/docs/charts/pie/pie.png`.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/julien-duponchelle/colvert/issues/15?shareId=254d0af4-0373-4ab7-b199-cd077f908246).