### PR TITLE
Add pytest and ruff to GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: Continuous Integration
+
+on:
+  pull_request:
+    branches:
+      - '*'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+          cache-dependency-path: 'requirements_dev.txt'
+      - name: Install dependencies
+        run: pip install -r requirements_dev.txt
+      - name: Run tests
+        run: PYTHONPATH=. pytest
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+      - name: Install dependencies
+        run: pip install ruff
+      - name: Run ruff
+        run: ruff check .


### PR DESCRIPTION
Related to #23

Adds a new GitHub Actions workflow to run pytest and ruff on every pull request.
- **Workflow Setup**: Introduces a new file `.github/workflows/ci.yml` that defines a Continuous Integration workflow.
- **Trigger**: Configures the workflow to activate on pull request events for all branches.
- **Python Environment**: Sets up a Python 3.11 environment and caches pip to speed up future runs.
- **Dependency Installation**: Installs dependencies from `requirements_dev.txt` using pip, ensuring all necessary packages are available for testing and linting.
- **Testing**: Adds a step to run pytest, executing all tests to verify code functionality.
- **Linting**: Includes a step to run ruff, performing code linting to maintain code quality standards. 
---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/julien-duponchelle/colvert/issues/23?shareId=22cee347-408e-4a57-bbd2-f0181d9d582f).