### PR TITLE
Fix side by side toggle click issue

### DIFF
--- a/colvert/ui/templates/index.html.j2
+++ b/colvert/ui/templates/index.html.j2
@@ -102,20 +102,16 @@
         }
     }
     document.addEventListener('DOMContentLoaded', hideRunButtonIfAutoRun);
+
     function toggleSideBySideCheckbox() {
         const chartType = document.querySelector('select[name="chart"]').value;
-        const sideBySideCheckbox = document.querySelector('input[name="side-by-side"]');
-        const sideBySideLabel = document.querySelector('label[for="side-by-side"]');
+        const sideBySideCheckbox = document.getElementById('side-by-side-checkbox')
         if (chartType === "table") {
-            sideBySideCheckbox.disabled = true;
-            sideBySideCheckbox.checked = false;
-            sideBySideLabel.style.display = "none";
+            sideBySideCheckbox.style.display = "none";
         } else {
-            sideBySideCheckbox.disabled = false;
-            sideBySideLabel.style.display = "block";
+            sideBySideCheckbox.style.display = "block";
         }
     }
-    document.querySelector('select[name="chart"]').addEventListener('change', toggleSideBySideCheckbox);
     document.addEventListener('DOMContentLoaded', toggleSideBySideCheckbox);
 </script>
 
@@ -129,12 +125,12 @@
         >
         <div class="card-body">
             <label for="chart" class="form-label">Chart type</label>
-            <select name="chart" class="form-select" onchange="runQueryIfAutoRun()">
+            <select name="chart" class="form-select" onchange="runQueryIfAutoRun();toggleSideBySideCheckbox()">
                 <option value="table">Table</option>
                 <option value="pie">Pie Chart</option>
                 <option value="line">Line Chart</option>
             </select>
-            <div class="form-check form-switch">
+            <div class="form-check form-switch" id="side-by-side-checkbox">
                 <input
                     type="checkbox"
                     name="side-by-side"

--- a/colvert/ui/templates/index.html.j2
+++ b/colvert/ui/templates/index.html.j2
@@ -101,7 +101,22 @@
             document.querySelector('input[type=submit]').style.display = 'block';
         }
     }
-    window.onload = hideRunButtonIfAutoRun;
+    document.addEventListener('DOMContentLoaded', hideRunButtonIfAutoRun);
+    function toggleSideBySideCheckbox() {
+        const chartType = document.querySelector('select[name="chart"]').value;
+        const sideBySideCheckbox = document.querySelector('input[name="side-by-side"]');
+        const sideBySideLabel = document.querySelector('label[for="side-by-side"]');
+        if (chartType === "table") {
+            sideBySideCheckbox.disabled = true;
+            sideBySideCheckbox.checked = false;
+            sideBySideLabel.style.display = "none";
+        } else {
+            sideBySideCheckbox.disabled = false;
+            sideBySideLabel.style.display = "block";
+        }
+    }
+    document.querySelector('select[name="chart"]').addEventListener('change', toggleSideBySideCheckbox);
+    document.addEventListener('DOMContentLoaded', toggleSideBySideCheckbox);
 </script>
 
 <div class="row">


### PR DESCRIPTION
Related to #18

Implements a dynamic toggle for the side-by-side checkbox based on the selected chart type in `colvert/ui/templates/index.html.j2`.

- **JavaScript Enhancements**: Adds a new function `toggleSideBySideCheckbox` that disables the side-by-side checkbox and hides its label when the chart type is set to "table". This function is called both on document load and whenever the chart type selection changes.
- **Event Listener Updates**: Replaces the `window.onload` event with `document.addEventListener('DOMContentLoaded', ...)` for invoking `hideRunButtonIfAutoRun` function, ensuring better compatibility and execution after the full document is parsed.
- **UI Interaction**: Ensures the side-by-side checkbox is only interactive when applicable, enhancing user experience by preventing confusion with non-functional UI elements in certain contexts.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/julien-duponchelle/colvert/issues/18?shareId=66f977a1-58ee-4810-857f-cf929f9973f3).