### PR TITLE
Fix the links in the documentation by auto removing /index.md

### DIFF
--- a/colvert/tests/ui/routes/test_docs.py
+++ b/colvert/tests/ui/routes/test_docs.py
@@ -9,9 +9,17 @@ async def test_index(http_server):
     content = await resp.content.read()
     assert b'Charts' in content
 
+
+@pytest.mark.asyncio
+async def test_replace_index_md(http_server):
+    resp = await http_server.get("/docs")
+    assert resp.status == 200
+    content = await resp.content.read()
+    assert b'/charts' in content
+
 @pytest.mark.asyncio
 async def test_path(http_server):
-    resp = await http_server.get("/docs/charts/pie/index")
+    resp = await http_server.get("/docs/charts/pie/index.md")
     assert resp.status == 200
     content = await resp.content.read()
     assert b'Hole' in content

--- a/colvert/ui/routes/docs.py
+++ b/colvert/ui/routes/docs.py
@@ -34,7 +34,6 @@ class ColvertAdmonitionExtension(AdmonitionExtension):
 
 
 def path(file: str) -> str:
-    
     return os.path.join(os.path.dirname(__file__), "..", "..", "docs", file)
 
 def render(file: str) -> str:
@@ -51,12 +50,16 @@ def render(file: str) -> str:
 async def index(request) -> dict[str, str]:
     return {"html": render("index.md")}
 
-
 @routes.get("/docs/{file:[a-z-/]+}.png")
 async def get_png(request) -> web.Response:
     file = request.match_info["file"]
     return web.Response(body=open(path(file + ".png"), "rb").read(), content_type="image/png")
 
+@routes.get("/docs/{file:[a-z-/]+}.md")
+@aiohttp_jinja2.template("docs.html.j2")
+async def get_md(request) -> dict[str, str]:
+    file = request.match_info["file"]
+    return {"html": render(file + ".md")}
 
 @routes.get("/docs/{file:[a-z-/]+}")
 @aiohttp_jinja2.template("docs.html.j2")


### PR DESCRIPTION
The index.md added to make the link work on Github was breaking the routes. Now we support index.md in the URL.

Fix #26 