### PR TITLE
Catch conversion errors

### DIFF
--- a/colvert/database/__init__.py
+++ b/colvert/database/__init__.py
@@ -1,6 +1,6 @@
 from .database import Database
-from .error import ParseError
+from .error import ProgrammingError
 from .query import Query
 from .result import Result
 
-__all__ = ["Database", "ParseError", "Result", "Query"]
+__all__ = ["Database", "ProgrammingError", "Result", "Query"]

--- a/colvert/database/database.py
+++ b/colvert/database/database.py
@@ -6,7 +6,7 @@ from typing import Generator, List, Optional
 
 import duckdb
 
-from .error import ParseError
+from .error import ProgrammingError
 from .query import Query
 from .result import Result
 
@@ -131,7 +131,7 @@ class Database:
         try:
             result = await asyncio.get_event_loop().run_in_executor(None, self._db.execute, str(sql), params)
         except duckdb.ProgrammingError as e:
-            raise ParseError(e)
+            raise ProgrammingError(e)
         return Result(result)
 
     async def sql(self, sql: Query) -> Result:
@@ -141,8 +141,8 @@ class Database:
         logging.info(sql)
         try:
             result = await asyncio.get_event_loop().run_in_executor(None, self._db.sql, str(sql))
-        except (duckdb.ProgrammingError, duckdb.IOException, duckdb.NotImplementedException) as e:
-            raise ParseError(e)
+        except (duckdb.ProgrammingError, duckdb.IOException, duckdb.NotImplementedException, duckdb.ConversionException) as e:
+            raise ProgrammingError(e)
         return Result(result)
     
     async def complete(self, query: str) -> list[tuple[str, str]]:

--- a/colvert/database/error.py
+++ b/colvert/database/error.py
@@ -1,5 +1,8 @@
 import duckdb
 
 
-class ParseError(duckdb.ParserException):
+class ProgrammingError(duckdb.ParserException):
+    """
+    A user error occurred
+    """
     pass

--- a/colvert/database/result.py
+++ b/colvert/database/result.py
@@ -1,4 +1,7 @@
+import duckdb
 import pandas
+
+from .error import ProgrammingError
 
 
 class Result:
@@ -32,4 +35,7 @@ class Result:
     def df(self) -> pandas.DataFrame:
         if self.result is None:
             return pandas.DataFrame()
-        return self.result.df()
+        try:
+            return self.result.df()
+        except duckdb.ConversionException as e:
+            raise ProgrammingError(e)

--- a/colvert/tests/database/test_database.py
+++ b/colvert/tests/database/test_database.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import pytest
 import pytest_asyncio
 
-from colvert.database import Database, Query
+from colvert.database import Database, ProgrammingError, Query
 
 
 class TestDatabase:
@@ -77,6 +77,11 @@ class TestDatabase:
     async def test_sql(self, db):
         res = await db.sql(Query("SELECT COUNT(*) FROM test"))
         assert res.fetchone()[0] == 12
+
+    @pytest.mark.asyncio
+    async def test_sql_error(self, db):
+        with pytest.raises(ProgrammingError):
+            await db.sql(Query("SELECT * FROM blal"))
 
     @pytest.mark.asyncio
     async def test_complete(self, db):

--- a/colvert/tests/ui/routes/test_results.py
+++ b/colvert/tests/ui/routes/test_results.py
@@ -67,3 +67,15 @@ async def test_post_results_error(http_server_sample_db):
     assert resp.status == 200
     assert "Parser Error:" in await resp.text()
     
+@pytest.mark.asyncio
+async def test_post_results_conversion_error(http_server_sample_db):
+    resp = await http_server_sample_db.post(
+        "/results",
+        data={
+            "q": 'SELECT COUNT(*) FROM test WHERE \'WRONG\'',
+            "chart": "table"
+        }
+    )
+    assert resp.status == 200
+    assert "Conversion Error" in await resp.text()
+    

--- a/colvert/ui/routes/results.py
+++ b/colvert/ui/routes/results.py
@@ -3,7 +3,7 @@ import logging
 from aiohttp import web
 from plotly.offline.offline import get_plotlyjs
 
-from ...database import ParseError, Query
+from ...database import ProgrammingError, Query
 from .. import charts
 from ..components import error_box, info_box, warning_box
 
@@ -33,7 +33,7 @@ async def index(request: web.Request) -> web.Response:
 
     try:
         result = await request.app["db"].sql(query)
-    except ParseError as e:
+    except ProgrammingError as e:
         logging.error(e)
         return await error_box(str(e), request)
     if result is None:
@@ -48,7 +48,7 @@ async def index(request: web.Request) -> web.Response:
             return await render_side_by_side(chart_type, request, result, options)
         else:
             return await render_full(chart_type, request, result, options)
-    except ValueError as e:
+    except (ValueError, ProgrammingError) as e:
         logging.error(e)
         return await error_box(str(e), request)
     


### PR DESCRIPTION
DuckDB raise an exception in case of conversion errors, like wrong equality in the WHERE clause or bad casting.

Fix #17, #13